### PR TITLE
Update repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/catalogueglobal/datatools-ui.git"
+    "url": "https://github.com/conveyal/datatools-ui.git"
   },
   "author": "Conveyal LLC",
   "license": "MIT",


### PR DESCRIPTION
Active development is returning to the Conveyal organization repo (see #276). As such, we need to update the repo URL in order for automated releases to work correctly.