### PR TITLE
Refactor columns out of timetable store

### DIFF
--- a/lib/editor/actions/trip.js
+++ b/lib/editor/actions/trip.js
@@ -8,7 +8,7 @@ import {setErrorMessage} from '../../manager/actions/status'
 import {entityIsNew} from '../util/objects'
 import {getEditorNamespace} from '../util/gtfs'
 
-import type {Pattern, Trip} from '../../types'
+import type {Pattern, TimetableColumn, Trip} from '../../types'
 import type {dispatchFn, getStateFn, TripCounts} from '../../types/reducers'
 
 export const addNewTrip = createAction(
@@ -18,7 +18,7 @@ export const addNewTrip = createAction(
 const deletingTrips = createVoidPayloadAction('DELETING_TRIPS_FOR_CALENDAR')
 export const offsetRows = createAction(
   'OFFSET_ROWS',
-  (payload: {offset: number, rowIndexes: Array<number>}) => payload
+  (payload: {columns: TimetableColumn[], offset: number, rowIndexes: number[]}) => payload
 )
 const receiveTripCounts = createAction(
   'RECEIVE_TRIP_COUNTS',

--- a/lib/editor/components/timetable/Timetable.js
+++ b/lib/editor/components/timetable/Timetable.js
@@ -56,12 +56,13 @@ export default class Timetable extends Component<Props> {
   render () {
     const {
       addNewRow,
+      columns,
       timetable,
       scrollToRow,
       scrollToColumn,
       updateCellValue
     } = this.props
-    const {columns, trips: data, selected, hideDepartureTimes} = timetable
+    const {trips: data, selected, hideDepartureTimes} = timetable
     // if no columns (and no data), page is still loading
     if (columns.length === 0 && data.length === 0) {
       return (

--- a/lib/editor/components/timetable/TimetableEditor.js
+++ b/lib/editor/components/timetable/TimetableEditor.js
@@ -28,7 +28,7 @@ type Props = ContainerProps & {
   activeSchedule: string,
   activeScheduleId: string,
   addNewTrip: typeof tripActions.addNewTrip,
-  columns?: Array<TimetableColumn>,
+  columns: Array<TimetableColumn>,
   data?: Array<Trip>,
   deleteTripsForCalendar: typeof tripActions.deleteTripsForCalendar,
   feedSource: Feed,
@@ -129,7 +129,7 @@ export default class TimetableEditor extends Component<Props, State> {
   }
 
   _offsetWithDefaults = (negative: boolean = false) => {
-    const {offsetRows, timetable} = this.props
+    const {columns, offsetRows, timetable} = this.props
     const rowIndexes = this._getSelectedRowIndexes()
     const {offset: currentOffset} = timetable
     const offset = negative ? currentOffset * -1 : currentOffset
@@ -137,7 +137,7 @@ export default class TimetableEditor extends Component<Props, State> {
       console.warn(`invalid offset value=${offset}`)
       return
     }
-    offsetRows({rowIndexes, offset})
+    offsetRows({columns, rowIndexes, offset})
   }
 
   cloneSelectedTrips = () => this.duplicateRows(this._getSelectedRowIndexes())
@@ -200,8 +200,8 @@ export default class TimetableEditor extends Component<Props, State> {
         objectPath.set(newRow, `stopTimes.${i}.stopSequence`, i)
         // }
       }
-      for (let i = 0; i < this.props.timetable.columns.length; i++) {
-        const col = this.props.timetable.columns[i]
+      for (let i = 0; i < this.props.columns.length; i++) {
+        const col = this.props.columns[i]
         if (isTimeFormat(col.type)) {
           // TODO: add default travel/dwell times to new rows
           // objectPath.ensureExists(newRow, col.key, 0)

--- a/lib/editor/containers/ActiveTimetableEditor.js
+++ b/lib/editor/containers/ActiveTimetableEditor.js
@@ -10,7 +10,6 @@ import {
   fetchTripsForCalendar,
   offsetRows,
   removeTrips,
-  // saveNewTrip,
   saveTripsForCalendar,
   setActiveCell,
   setOffset,
@@ -45,11 +44,8 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
   const project = findProjectByFeedSource(state.projects.all, feedSourceId)
   const feedSource = project && project.feedSources && project.feedSources.find(fs => fs.id === feedSourceId)
   const tripCounts = getTripCounts(state)
-  // $FlowFixMe seems like reselect flow-typed library should work, but it doesn't
   const columns = getTimetableColumns(state)
   const tripValidationErrors = getTripValidationErrors(state)
-  // $FlowFixMe TODO: write comment what this code is doing
-  timetable.columns = columns
   const {subEntity: activePattern} = active
   const activeSchedule = getTableById(tables, 'calendar')
     .find(c => c.service_id === activeScheduleId)
@@ -59,6 +55,7 @@ const mapStateToProps = (state: AppState, ownProps: Props) => {
     activeScheduleId,
     activePattern,
     activeSchedule,
+    columns,
     feedSource,
     tableData: tables,
     timetable,

--- a/lib/editor/reducers/timetable.js
+++ b/lib/editor/reducers/timetable.js
@@ -18,7 +18,6 @@ export const defaultState = {
     fetching: false
   },
   activeCell: null,
-  columns: [],
   trips: [],
   edited: [],
   selected: [],
@@ -94,8 +93,8 @@ const timetable = (state: TimetableState = defaultState, action: Action): Timeta
       // console.log(`Offsetting ${action.payload.rowIndexes.length} rows by ${action.payload.offset} seconds`)
       for (var i = 0; i < action.payload.rowIndexes.length; i++) {
         editedRows.push(action.payload.rowIndexes[i])
-        for (var j = 0; j < state.columns.length; j++) {
-          const col = state.columns[j]
+        for (var j = 0; j < action.payload.columns.length; j++) {
+          const col = action.payload.columns[j]
           const path = `${action.payload.rowIndexes[i]}.${col.key}`
           if (isTimeFormat(col.type)) {
             const currentVal = objectPath.get(trips, path)

--- a/lib/types/reducers.js
+++ b/lib/types/reducers.js
@@ -16,7 +16,6 @@ import type {
   ServerJob,
   ShapePoint,
   Sign,
-  TimetableColumn,
   Trip,
   UserProfile
 } from './'
@@ -216,7 +215,6 @@ export type MapState = {
 
 export type TimetableState = {
   +activeCell: ?string,
-  +columns: Array<TimetableColumn>,
   +edited: Array<number>,
   +hideDepartureTimes: boolean,
   +offset: number,


### PR DESCRIPTION
This PR addresses some weirdness in the timetable state/store where the timetable columns were computed by a selector but passed into the active timetable editor container as part of the timetable store/state.