### PR TITLE
Feed version tabs and home fixes

### DIFF
--- a/lib/manager/actions/feeds.js
+++ b/lib/manager/actions/feeds.js
@@ -4,6 +4,7 @@ import {browserHistory} from 'react-router'
 import {createAction, type ActionType} from 'redux-actions'
 
 import {createVoidPayloadAction, secureFetch} from '../../common/actions'
+import {isModuleEnabled} from '../../common/util/config'
 import {fetchFeedSourceDeployments} from './deployments'
 import {fetchSnapshots} from '../../editor/actions/snapshots'
 import {fetchProject, fetchProjectWithFeeds} from './projects'
@@ -162,7 +163,7 @@ function fetchRelatedTables (feedSource: Feed) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     dispatch(fetchFeedVersions(feedSource))
     dispatch(fetchSnapshots(feedSource))
-    dispatch(fetchFeedSourceDeployments(feedSource))
+    isModuleEnabled('deployment') && dispatch(fetchFeedSourceDeployments(feedSource))
   }
 }
 

--- a/lib/manager/actions/user.js
+++ b/lib/manager/actions/user.js
@@ -275,7 +275,8 @@ export function onUserHomeMount (user: ?ManagerUserState, projectId: ?string) {
             }
           })
           projectId = userProjectIds && userProjectIds[0]
-        } else {
+        }
+        if (projectId) {
           const _projectId = projectId
           dispatch(fetchProjectFeeds(_projectId))
             .then(() => browserHistory.push(`/home/${_projectId}`))

--- a/lib/manager/components/reporter/components/PatternLayout.js
+++ b/lib/manager/components/reporter/components/PatternLayout.js
@@ -23,12 +23,13 @@ import TripsPerHourChart from './TripsPerHourChart'
 
 import type {Props as ContainerProps} from '../containers/Patterns'
 import type {FetchStatus} from '../../../../types'
-import type {AllRoutesSubState} from '../../../../types/reducers'
+import type {AllRoutesSubState, RouteListItem} from '../../../../types/reducers'
 import type {PatternRowData} from '../../../selectors'
 
 type Props = ContainerProps & {
   fetchRoutes: typeof routesActions.fetchRoutes,
   fetchStatus: FetchStatus,
+  namespace: string,
   patternData: Array<PatternRowData>,
   patternDateTimeFilterChange: typeof patternsActions.patternDateTimeFilterChange,
   patternRouteFilterChange: typeof patternsActions.patternRouteFilterChange,
@@ -46,6 +47,11 @@ export default class PatternLayout extends Component<Props> {
     }
   }
 
+  _onSelectRoute = (newRoute: ?RouteListItem) => {
+    const {namespace, patternRouteFilterChange} = this.props
+    patternRouteFilterChange(namespace, newRoute ? newRoute.route_id : undefined)
+  }
+
   render () {
     const {
       fetchStatus: {
@@ -56,7 +62,6 @@ export default class PatternLayout extends Component<Props> {
       patternData,
       patternDateTimeFilterChange,
       routeFilter,
-      patternRouteFilterChange,
       routes,
       selectTab,
       version,
@@ -87,7 +92,7 @@ export default class PatternLayout extends Component<Props> {
                   valueKey={'route_id'}
                   placeholder={'Select a Route'}
                   value={routeFilter}
-                  onChange={patternRouteFilterChange} />
+                  onChange={this._onSelectRoute} />
               </Col>
             </Row>
             <ActiveDateTimeFilter

--- a/lib/manager/components/reporter/components/PatternLayout.js
+++ b/lib/manager/components/reporter/components/PatternLayout.js
@@ -111,8 +111,8 @@ export default class PatternLayout extends Component<Props> {
             An error occurred while trying to fetch the data
           </Alert>
         }
-
-        {fetched &&
+        /* Only display results if query completed and a route is selected. */
+        {fetched && routeFilter &&
           <Row style={{marginTop: 20}}>
             <Col xs={12}>
               <ListGroup className='route-list'>

--- a/lib/manager/components/reporter/components/PatternLayout.js
+++ b/lib/manager/components/reporter/components/PatternLayout.js
@@ -111,7 +111,7 @@ export default class PatternLayout extends Component<Props> {
             An error occurred while trying to fetch the data
           </Alert>
         }
-        /* Only display results if query completed and a route is selected. */
+        {/* Only display results if query completed and a route is selected. */}
         {fetched && routeFilter &&
           <Row style={{marginTop: 20}}>
             <Col xs={12}>

--- a/lib/manager/components/reporter/components/RouteLayout.js
+++ b/lib/manager/components/reporter/components/RouteLayout.js
@@ -29,6 +29,7 @@ type Props = ContainerProps & {
   fetchRouteDetails: typeof routesActions.fetchRouteDetails,
   fetchRoutes: typeof routesActions.fetchRoutes,
   fetchStatus: FetchStatus,
+  namespace: string,
   numRoutes: number,
   patternRouteFilterChange: typeof patternsActions.patternRouteFilterChange,
   routeData: Array<RouteRowData>,
@@ -77,6 +78,7 @@ export default class RouteLayout extends Component<Props> {
         fetching,
         fetched
       },
+      namespace,
       numRoutes,
       patternRouteFilterChange,
       routeData,
@@ -137,6 +139,7 @@ export default class RouteLayout extends Component<Props> {
                     {...route}
                     index={index}
                     maxTripsPerHourAllRoutes={maxTripsPerHourAllRoutes}
+                    namespace={namespace}
                     patternRouteFilterChange={patternRouteFilterChange}
                     selectTab={selectTab} />
                 ))}

--- a/lib/manager/components/reporter/containers/Patterns.js
+++ b/lib/manager/components/reporter/containers/Patterns.js
@@ -23,6 +23,7 @@ export type Props = {
 const mapStateToProps = (state: AppState, ownProps: Props) => {
   return {
     fetchStatus: state.gtfs.patterns.fetchStatus,
+    namespace: ownProps.version.namespace,
     routes: state.gtfs.routes.allRoutes,
     routeFilter: state.gtfs.filter.routeFilter,
     patternData: getPatternData(state)


### PR DESCRIPTION
- Make it so there is no error when loading patterns in the feed version navigator.
- Make a project load after the home page mounts