### PR TITLE
Remove babel-polyfill as a primary dependency

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,3 @@
-import 'babel-polyfill'
 import mount from '@conveyal/woonerf/mount'
 
 import admin from './admin/reducers'

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@turf/nearest-point-on-line": "^5.1.5",
     "auth0-js": "^9.3.2",
     "auth0-lock": "^11.3.1",
-    "babel-polyfill": "^6.22.0",
     "bootstrap": "^3.3.7",
     "bugsnag-js": "^4.7.2",
     "bugsnag-react": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,7 +1623,7 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-polyfill@^6.16.0, babel-polyfill@^6.22.0:
+babel-polyfill@^6.16.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
   integrity sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Removes a temporary hack that's probably had a fix available for a while. Fixes #6.