### PR TITLE
fix(editor): fix undo button

### DIFF
--- a/lib/editor/components/EntityDetails.js
+++ b/lib/editor/components/EntityDetails.js
@@ -33,7 +33,7 @@ type Props = {
   newGtfsEntity: typeof editorActions.newGtfsEntity,
   offset: number,
   project: Project,
-  resetActiveEntity: typeof activeActions.resetActiveGtfsEntity,
+  resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
   setActiveEntity: typeof activeActions.setActiveEntity,
   showConfirmModal: any,
@@ -115,7 +115,6 @@ export default class EntityDetails extends Component<Props, State> {
     return (
       <div style={panelStyle}>
         <div className='entity-details'>
-          {/* // $FlowFixMe */}
           <EntityDetailsHeader
             validationErrors={validationErrors}
             editFareRules={this.state.editFareRules}

--- a/lib/editor/components/EntityDetailsHeader.js
+++ b/lib/editor/components/EntityDetailsHeader.js
@@ -24,11 +24,11 @@ type Props = {
   entityEdited: boolean,
   feedSource: Feed,
   mapState: MapState,
-  resetActiveEntity: typeof activeActions.resetActiveGtfsEntity,
+  resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
   setActiveEntity: typeof activeActions.setActiveEntity,
   subComponent: string,
-  subEntityId: number,
+  subEntity: number,
   toggleEditFareRules: boolean => void,
   updateMapSetting: typeof mapActions.updateMapSetting,
   validationErrors: Array<EditorValidationIssue>
@@ -48,26 +48,26 @@ export default class EntityDetailsHeader extends Component<Props> {
       activeComponent,
       activeEntity,
       activePattern,
-      resetActiveEntity,
+      resetActiveGtfsEntity,
       subComponent
     } = this.props
     if (subComponent === 'trippattern') {
       const castedRoute = ((activeEntity: any): RouteWithPatterns)
       const pattern = castedRoute.tripPatterns.find(p => p.id === activePattern.id)
-      if (pattern) resetActiveEntity({ entity: pattern, component: 'trippattern' })
+      if (pattern) resetActiveGtfsEntity({ entity: pattern, component: 'trippattern' })
       else console.warn(`Could not locate pattern with id=${activePattern.id}`)
     } else {
-      resetActiveEntity({ entity: activeEntity, component: activeComponent })
+      resetActiveGtfsEntity({ entity: activeEntity, component: activeComponent })
     }
   }
 
   _onClickZoomTo = () => {
-    const { activeEntity, subEntityId, updateMapSetting } = this.props
+    const { activeEntity, subEntity, updateMapSetting } = this.props
     let props
-    if (subEntityId) {
+    if (subEntity) {
       const castedRoute = ((activeEntity: any): RouteWithPatterns)
-      const pattern = castedRoute.tripPatterns.find(p => p.id === subEntityId)
-      props = { bounds: getEntityBounds(pattern), target: subEntityId }
+      const pattern = castedRoute.tripPatterns.find(p => p.id === subEntity)
+      props = { bounds: getEntityBounds(pattern), target: subEntity }
     } else {
       props = { bounds: getEntityBounds(activeEntity), target: +activeEntity.id }
     }
@@ -112,7 +112,7 @@ export default class EntityDetailsHeader extends Component<Props> {
       entityEdited,
       mapState,
       subComponent,
-      subEntityId,
+      subEntity,
       validationErrors
     } = this.props
     const validationTooltip = (
@@ -129,7 +129,7 @@ export default class EntityDetailsHeader extends Component<Props> {
     const icon = GTFS_ICONS.find(i => i.id === activeComponent)
     const zoomDisabled = activeEntity && !subComponent
       ? mapState.target === activeEntity.id
-      : mapState.target === subEntityId
+      : mapState.target === subEntity
     const iconName = icon ? icon.icon : null
     const nameWidth = activeComponent === 'stop' || activeComponent === 'route'
       ? '176px'

--- a/lib/editor/components/EntityList.js
+++ b/lib/editor/components/EntityList.js
@@ -28,6 +28,7 @@ type Props = ContainerProps & {
   hasRoutes: boolean,
   list: ImmutableList, // FIXME Immutable.List
   newGtfsEntity: typeof editorActions.newGtfsEntity,
+  resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   setActiveEntity: typeof activeActions.setActiveEntity,
   sort: DataStateSort,
   updateActiveGtfsEntity: typeof activeActions.updateActiveGtfsEntity,

--- a/lib/editor/components/GtfsEditor.js
+++ b/lib/editor/components/GtfsEditor.js
@@ -95,7 +95,7 @@ type Props = ContainerProps & {
   removeControlPoint: typeof mapActions.removeControlPoint,
   removeEditorLock: typeof editorActions.removeEditorLock,
   removeStopFromPattern: typeof stopStrategiesActions.removeStopFromPattern,
-  resetActiveEntity: typeof activeActions.resetActiveGtfsEntity,
+  resetActiveGtfsEntity: typeof activeActions.resetActiveGtfsEntity,
   saveActiveGtfsEntity: typeof activeActions.saveActiveGtfsEntity,
   setActiveEntity: typeof activeActions.setActiveEntity,
   setActiveGtfsEntity: typeof activeActions.setActiveGtfsEntity,

--- a/lib/editor/containers/ActiveEntityList.js
+++ b/lib/editor/containers/ActiveEntityList.js
@@ -5,6 +5,7 @@ import {connect} from 'react-redux'
 import {
   deleteGtfsEntity,
   enterTimetableEditor,
+  resetActiveGtfsEntity,
   setActiveEntity,
   updateActiveGtfsEntity
 } from '../actions/active'
@@ -53,6 +54,7 @@ const mapDispatchToProps = {
   deleteGtfsEntity,
   enterTimetableEditor,
   newGtfsEntity,
+  resetActiveGtfsEntity,
   setActiveEntity,
   updateActiveGtfsEntity,
   updateEntitySort


### PR DESCRIPTION
Fixes #416. This also removes a $FlowFixMe and changes `subEntityId` -> `subEntity` (`subEntityId` was never being passed to the component via `this.props`).