### PR TITLE
Silence yarn warning about options forwarding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - yarn run flow
   - yarn run cover-client
   - codecov
-  - yarn run build -- --minify
+  - yarn run build --minify
   - mkdocs build
 
 # If sudo is disabled, CI runs on container based infrastructure (allows caching &c.)


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [ ] ~Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented~
- [ ] ~The description lists all applicable issues this PR seeks to resolve~
- [ ] ~The description lists any configuration setting(s) that differ from the default settings~
- [x] All tests and CI builds passing

### Description

This silences a yarn warning thrown during CI by removing the `--` for options forwarding:

```
$ yarn run build -- --minify
yarn run v1.3.2
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```