### PR TITLE
Add shapefile export for feed versions

### DIFF
--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -3,6 +3,7 @@
 import {createAction, type ActionType} from 'redux-actions'
 
 import {createVoidPayloadAction, secureFetch} from '../../common/actions'
+import {API_PREFIX} from '../../common/constants'
 import {fetchDeployment} from './deployments'
 import {fetchFeedSource} from './feeds'
 import {downloadMergedFeedViaToken} from './projects'
@@ -154,6 +155,11 @@ export function handleFinishedJob (job: ServerJob) {
         }
         dispatch(fetchFeedSource(job.feedSourceId, true))
         break
+      case 'EXPORT_GIS':
+        // Download shapefile. NOTE: because this is a temporary file, which is
+        // immediately deleted, the server does not also provide an option to
+        // download via S3 (it never uploads the file to S3).
+        window.location.assign(`${API_PREFIX}downloadshapes/${job.jobId}`)
       case 'EXPORT_SNAPSHOT_TO_GTFS':
         if (job.parentJobId) {
           console.log('Not downloading snapshot GTFS. Export job part of feed version creation.')

--- a/lib/manager/actions/status.js
+++ b/lib/manager/actions/status.js
@@ -160,6 +160,7 @@ export function handleFinishedJob (job: ServerJob) {
         // immediately deleted, the server does not also provide an option to
         // download via S3 (it never uploads the file to S3).
         window.location.assign(`${API_PREFIX}downloadshapes/${job.jobId}`)
+        break
       case 'EXPORT_SNAPSHOT_TO_GTFS':
         if (job.parentJobId) {
           console.log('Not downloading snapshot GTFS. Export job part of feed version creation.')

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -14,7 +14,7 @@ import {getEntityGraphQLRoot, getEntityIdField, getGraphQLFieldsForEntity} from 
 import {handleJobResponse, setErrorMessage, startJobMonitor} from './status'
 import {fetchFeedSource} from './feeds'
 
-import type {Feed, FeedVersion} from '../../types'
+import type {Feed, FeedVersion, ShapefileExportType} from '../../types'
 import type {dispatchFn, getStateFn} from '../../types/reducers'
 
 const deletingFeedVersion = createVoidPayloadAction('DELETING_FEEDVERSION')
@@ -589,7 +589,7 @@ export function setVersionIndex (
  *
  * NOTE: server endpoint supports more than one feed version (comma separated).
  */
-export function exportVersionShapes (feedVersionId: string, type: 'STOPS' | 'ROUTES') {
+export function exportVersionShapes (feedVersionId: string, type: ShapefileExportType) {
   return function (dispatch: dispatchFn, getState: getStateFn) {
     const url = `${SECURE_API_PREFIX}feedversion/shapes?feedId=${feedVersionId}&type=${type}`
     return dispatch(secureFetch(url, 'post'))

--- a/lib/manager/actions/versions.js
+++ b/lib/manager/actions/versions.js
@@ -104,6 +104,7 @@ export const setActiveVersion = createAction(
 const uploadingFeed = createVoidPayloadAction('UPLOADING_FEED')
 
 export type VersionActions = ActionType<typeof deletingFeedVersion> |
+  ActionType<typeof exportVersionShapes> |
   ActionType<typeof publishedFeedVersion> |
   ActionType<typeof receiveFeedVersion> |
   ActionType<typeof receiveFeedVersionIsochrones> |
@@ -580,5 +581,18 @@ export function setVersionIndex (
         browserHistory.push(`${isPublic ? '/public' : ''}/feed/${feed.id}/version/${index}`)
       }
     }
+  }
+}
+
+/**
+ * Starts the export shapes server job for a particular feed version.
+ *
+ * NOTE: server endpoint supports more than one feed version (comma separated).
+ */
+export function exportVersionShapes (feedVersionId: string, type: 'STOPS' | 'ROUTES') {
+  return function (dispatch: dispatchFn, getState: getStateFn) {
+    const url = `${SECURE_API_PREFIX}feedversion/shapes?feedId=${feedVersionId}&type=${type}`
+    return dispatch(secureFetch(url, 'post'))
+      .then(res => dispatch(handleJobResponse(res, 'Error exporting GIS')))
   }
 }

--- a/lib/manager/components/version/FeedVersionNavigator.js
+++ b/lib/manager/components/version/FeedVersionNavigator.js
@@ -28,6 +28,7 @@ type Props = ContainerProps & {
   deleteFeedVersion: typeof versionsActions.deleteFeedVersion,
   downloadFeedViaToken: typeof versionsActions.downloadFeedViaToken,
   downloadGtfsPlusFeed: typeof gtfsPlusActions.downloadGtfsPlusFeed,
+  exportVersionShapes: typeof versionsActions.exportVersionShapes,
   feedVersionIndex: number,
   fetchGTFSEntities: typeof versionsActions.fetchGTFSEntities,
   fetchNotesForFeedVersion: typeof notesActions.fetchNotesForFeedVersion,
@@ -138,6 +139,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
       disabled,
       downloadFeedViaToken,
       editDisabled,
+      exportVersionShapes,
       feedSource,
       feedVersionIndex,
       fetchGTFSEntities,
@@ -297,6 +299,7 @@ export default class FeedVersionNavigator extends Component<Props, State> {
               downloadFeedViaToken={downloadFeedViaToken}
               downloadGtfsPlusFeed={this._onRequestGtfsPlusData}
               editDisabled={editDisabled}
+              exportVersionShapes={exportVersionShapes}
               feedSource={feedSource}
               feedVersionIndex={feedVersionIndex}
               fetchGTFSEntities={fetchGTFSEntities}

--- a/lib/manager/components/version/FeedVersionViewer.js
+++ b/lib/manager/components/version/FeedVersionViewer.js
@@ -25,6 +25,7 @@ export type Props = {
   downloadFeedViaToken: typeof versionsActions.downloadFeedViaToken,
   downloadGtfsPlusFeed: FeedVersion => void,
   editDisabled: ?boolean,
+  exportVersionShapes: typeof versionsActions.exportVersionShapes,
   feedSource: Feed,
   feedSource: Feed,
   feedVersionIndex: number,

--- a/lib/manager/components/version/VersionButtonToolbar.js
+++ b/lib/manager/components/version/VersionButtonToolbar.js
@@ -8,6 +8,7 @@ import ConfirmModal from '../../../common/components/ConfirmModal'
 import {getComponentMessages, isModuleEnabled} from '../../../common/util/config'
 
 import type {ListProps} from './FeedVersionViewer'
+import type {ShapefileExportType} from '../../../types'
 
 type ToolbarProps = ListProps & {size: string}
 
@@ -38,7 +39,7 @@ export default class VersionButtonToolbar extends Component<ToolbarProps> {
     })
   }
 
-  _onDownloadShapes = (type: 'STOPS' | 'ROUTES') => {
+  _onDownloadShapes = (type: ShapefileExportType) => {
     this.props.exportVersionShapes(this.props.version.id, type)
   }
 
@@ -67,7 +68,6 @@ export default class VersionButtonToolbar extends Component<ToolbarProps> {
             <span className='hidden-xs hidden-sm'> {this.messages('version')}</span>
           </Button>
           <DropdownButton
-            // componentClass={InputGroup.Button}
             bsSize={size}
             id='shp-export'
             title={

--- a/lib/manager/components/version/VersionButtonToolbar.js
+++ b/lib/manager/components/version/VersionButtonToolbar.js
@@ -2,7 +2,7 @@
 
 import Icon from '@conveyal/woonerf/components/icon'
 import React, {Component} from 'react'
-import {Button, Glyphicon, ButtonGroup} from 'react-bootstrap'
+import {Button, Glyphicon, ButtonGroup, DropdownButton, MenuItem} from 'react-bootstrap'
 
 import ConfirmModal from '../../../common/components/ConfirmModal'
 import {getComponentMessages, isModuleEnabled} from '../../../common/util/config'
@@ -38,6 +38,10 @@ export default class VersionButtonToolbar extends Component<ToolbarProps> {
     })
   }
 
+  _onDownloadShapes = (type: string) => {
+    this.props.exportVersionShapes(this.props.version.id, type)
+  }
+
   render () {
     const {
       deleteDisabled,
@@ -62,7 +66,20 @@ export default class VersionButtonToolbar extends Component<ToolbarProps> {
             <span className='hidden-xs'> {this.messages('download')}</span>
             <span className='hidden-xs hidden-sm'> {this.messages('version')}</span>
           </Button>
-
+          <DropdownButton
+            // componentClass={InputGroup.Button}
+            bsSize={size}
+            id='shp-export'
+            title={
+              <span>
+                <Icon type='file-zip-o' />
+                <span className='hidden-xs'> Export (.shp)</span>
+              </span>
+            }
+            onSelect={this._onDownloadShapes}>
+            <MenuItem eventKey='STOPS'><Icon type='map-marker' /> Stops</MenuItem>
+            <MenuItem eventKey='ROUTES'><Icon type='ellipsis-h' /> Routes</MenuItem>
+          </DropdownButton>
           {/* "Load for Editing" Button */}
           {isModuleEnabled('editor') && !isPublic
             ? <Button

--- a/lib/manager/components/version/VersionButtonToolbar.js
+++ b/lib/manager/components/version/VersionButtonToolbar.js
@@ -38,7 +38,7 @@ export default class VersionButtonToolbar extends Component<ToolbarProps> {
     })
   }
 
-  _onDownloadShapes = (type: string) => {
+  _onDownloadShapes = (type: 'STOPS' | 'ROUTES') => {
     this.props.exportVersionShapes(this.props.version.id, type)
   }
 

--- a/lib/manager/containers/ActiveFeedVersionNavigator.js
+++ b/lib/manager/containers/ActiveFeedVersionNavigator.js
@@ -9,6 +9,7 @@ import {
 import {
   deleteFeedVersion,
   downloadFeedViaToken,
+  exportVersionShapes,
   fetchGTFSEntities,
   fetchValidationErrors,
   fetchValidationIssueCount,
@@ -92,6 +93,7 @@ const mapDispatchToProps = {
   deleteFeedVersion,
   downloadFeedViaToken,
   downloadGtfsPlusFeed,
+  exportVersionShapes,
   fetchGTFSEntities,
   fetchNotesForFeedVersion,
   fetchValidationErrors,

--- a/lib/types/index.js
+++ b/lib/types/index.js
@@ -768,3 +768,5 @@ export type FetchStatus = {
 export type TripCountItems = Array<{count: number, type: string}>
 
 export type TripCounts = {[string]: TripCountItems} & ?{[string]: TripCounts}
+
+export type ShapefileExportType = 'STOPS' | 'ROUTES'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,7 +3502,7 @@ debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5670,7 +5670,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7194,11 +7194,6 @@ lodash-es@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7207,29 +7202,12 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
 
-lodash._getnative@*, lodash._getnative@^3.0.0:
+lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
   integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
@@ -7337,11 +7315,6 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -10763,7 +10736,7 @@ readable-stream@~2.0.0, readable-stream@~2.0.6:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JSDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

Adds dropdown button to VersionButtonToolbar for exporting shapefile of feed version's stops or routes. Fixes conveyal/datatools-server#34.

![image](https://user-images.githubusercontent.com/2370911/57311983-ae2e2b00-70ba-11e9-8d99-075d6ada4cac.png)
